### PR TITLE
[Feature] Split transmission capacity variable into existing and new.…

### DIFF
--- a/highres.gms
+++ b/highres.gms
@@ -38,7 +38,11 @@ $offdigit
 * model_yr = which year in the future are we modelling
 * weather_yr = which weather year do we use
 * dem_yr = which demand year do we use
-* fx_trans (YES/NO) = fix transmission network to input values
+* trans_inv (OFF/TYNDP/USER) = new transmission capacity either:
+*               i) no new transmission investment permitted
+*               ii) upper limit based on TYNDP
+*               iii) investment capped to user value "trans_cap_lim"
+* trans_cap_lim = MW limit for each line available in model
 * fx_caps_to = file containing capacities to fix the system to
 * co2intensity = Average annual carbon dioxide emission intensity
 *                the model is allowed to produce (gCO2/kWh)
@@ -93,7 +97,8 @@ $setglobal vre_restrict ""
 $setglobal model_yr "2050"
 $setglobal weather_yr "2010"
 $setglobal dem_yr "2010"
-$setglobal fx_trans "NO"
+$setglobal trans_inv "TYNDP"
+$setglobal trans_cap_lim "20"
 $setglobal fx_caps_to ""
 $setglobal co2intensity "2"
 $setglobal emis_price "0"
@@ -156,6 +161,7 @@ $label optimal1
 demand(z,h)=demand(z,h)/MWtoGW;
 gen_cap2area(vre)=gen_cap2area(vre)/MWtoGW;
 trans_links_cap(z,z_alias,trans)=trans_links_cap(z,z_alias,trans)/MWtoGW;
+trans_links_lim_cap(z,z_alias,trans)=trans_links_lim_cap(z,z_alias,trans)/MWtoGW;
 gen_unitsize(non_vre)=gen_unitsize(non_vre)/MWtoGW;
 gen_maxramp(non_vre)=gen_maxramp(non_vre)/MWtoGW;
 
@@ -327,8 +333,10 @@ var_vre_curtail(h,z,vre,r)         VRE power curtailed
 *var_non_vre_curtail(z,h,non_vre)
 var_trans_flow(h,z,z_alias,trans)  Flow of electricity from node to node by hour
 *                                  (MW)
-var_trans_pcap(z,z_alias,trans)    Capacity of node to node transmission links
+var_new_trans_pcap(z,z_alias,trans)    Capacity of node to node transmission links
 *                                  (MW)
+var_exist_trans_pcap(z,z_alias,trans)  Existing capacity of node to node
+*                                      transmissions links (MW)
 
 var_pgen(h,z)                      Penalty generation
 
@@ -362,18 +370,30 @@ trans_links_dist_bidir(z_alias,z,trans)$(trans_links_dist(z,z_alias,trans) > 0.)
 
 * Set transmission capacities to historic
 
-$ifThen "%fx_trans%" == "YES"
-
-var_trans_pcap.FX(z,z_alias,trans)$(trans_links(z,z_alias,trans))
+var_exist_trans_pcap.FX(z,z_alias,trans)$(trans_links(z,z_alias,trans))
     = trans_links_cap(z,z_alias,trans);
 
-$else
+$ifThen "%trans_inv%" == "OFF"
+
+var_new_trans_pcap.UP(z,z_alias,trans)$(trans_links(z,z_alias,trans))= 0;
+
+$elseif "%trans_inv%" == "TYNDP"
+
+trans_links_lim_cap(z_alias,z,trans)$(trans_links_lim_cap(z,z_alias,trans))
+    =trans_links_lim_cap(z,z_alias,trans);
+
+var_new_trans_pcap.UP(z,z_alias,trans)$(trans_links(z,z_alias,trans))=
+    trans_links_lim_cap(z,z_alias,trans);
+    
+$elseif "%trans_inv%" == "USER"
 
 * Or limit all links to some maximum
 
-var_trans_pcap.UP(z,z_alias,trans)$(trans_links(z,z_alias,trans))=50.;
+var_new_trans_pcap.UP(z,z_alias,trans)$(trans_links(z,z_alias,trans))=
+%trans_cap_lim%;
 
 $endIf
+
 
 
 
@@ -516,7 +536,8 @@ eq_gen_vre_r
 eq_area_max
 
 eq_trans_flow
-eq_trans_bidirect
+eq_trans_bidirect_new
+eq_trans_bidirect_exist
 $IF "%pen_gen%" == ON eq_pen_gen
 
 eq_co2_target
@@ -590,15 +611,27 @@ $endif
 
 eq_costs_trans_capex(z)..
     costs_trans_capex(z) =E= sum(trans_links(z,z_alias,trans),
-        var_trans_pcap(z,z_alias,trans)*trans_links_dist(z,z_alias,trans)
+        var_new_trans_pcap(z,z_alias,trans)*trans_links_dist(z,z_alias,trans)
         *trans_line_capex(trans))
     +sum(trans_links(z,z_alias,trans),
-        var_trans_pcap(z,z_alias,trans)$(trans_links_dist(z,z_alias,trans))
+        var_new_trans_pcap(z,z_alias,trans)$(trans_links_dist(z,z_alias,trans))
         *trans_sub_capex(trans)*2);
 
 * assume 2% fom costs for transmission
 
-eq_costs_trans_fom(z) .. costs_trans_fom(z) =E= costs_trans_capex(z)*0.02;
+eq_costs_trans_fom(z) ..
+    costs_trans_fom(z) =E=
+    
+        costs_trans_capex(z)*0.02
+        
+* add on 2% fom costs for existing transmission
+    
+        +(sum(trans_links(z,z_alias,trans),
+            var_exist_trans_pcap(z,z_alias,trans)*trans_links_dist(z,z_alias,trans)
+            *trans_line_capex(trans))
+        +sum(trans_links(z,z_alias,trans),
+            var_exist_trans_pcap(z,z_alias,trans)$(trans_links_dist(z,z_alias,trans))
+            *trans_sub_capex(trans)*2))*0.02;
 
 
 
@@ -719,13 +752,21 @@ eq_ramp_down(h,ramp_on(z,non_vre))$(gen_lin(z,non_vre))..
 * Transmitted electricity each hour must not exceed transmission capacity
 
 eq_trans_flow(h,trans_links(z,z_alias,trans))..
-    var_trans_flow(h,z,z_alias,trans) =L= var_trans_pcap(z,z_alias,trans);
 
-* Bidirectionality equation is needed when investments into new links are made
+    var_trans_flow(h,z,z_alias,trans) =L=
+    
+    (var_new_trans_pcap(z,z_alias,trans)
+    +var_exist_trans_pcap(z,z_alias,trans));
+
+* Bidirectionality equations is needed when investments into new links are made
 *   ...I think :)
 
-eq_trans_bidirect(trans_links(z,z_alias,trans))..
-    var_trans_pcap(z,z_alias,trans) =E= var_trans_pcap(z_alias,z,trans);
+eq_trans_bidirect_new(trans_links(z,z_alias,trans))..
+    var_new_trans_pcap(z,z_alias,trans) =E= var_new_trans_pcap(z_alias,z,trans);
+    
+eq_trans_bidirect_exist(trans_links(z,z_alias,trans))..
+    var_exist_trans_pcap(z,z_alias,trans) =E= var_exist_trans_pcap(z_alias,z,trans);
+
 
 
 ***********************

--- a/highres.gms
+++ b/highres.gms
@@ -333,6 +333,7 @@ var_vre_curtail(h,z,vre,r)         VRE power curtailed
 *var_non_vre_curtail(z,h,non_vre)
 var_trans_flow(h,z,z_alias,trans)  Flow of electricity from node to node by hour
 *                                  (MW)
+var_tot_trans_pcap(z,z_alias,trans) Total transmission capacity node to node
 var_new_trans_pcap(z,z_alias,trans)    Capacity of node to node transmission links
 *                                  (MW)
 var_exist_trans_pcap(z,z_alias,trans)  Existing capacity of node to node
@@ -535,6 +536,7 @@ eq_gen_vre_r
 
 eq_area_max
 
+eq_trans_tot_pcap
 eq_trans_flow
 eq_trans_bidirect_new
 eq_trans_bidirect_exist
@@ -748,6 +750,16 @@ eq_ramp_down(h,ramp_on(z,non_vre))$(gen_lin(z,non_vre))..
 ******************************
 *** Transmission equations ***
 ******************************
+
+* Transmission total power capacity
+
+eq_trans_tot_pcap(trans_links(z,z_alias,trans)) ..
+
+    var_tot_trans_pcap(z,z_alias,trans) =E=
+
+    var_new_trans_pcap(z,z_alias,trans)
+    + var_exist_trans_pcap(z,z_alias,trans);
+
 
 * Transmitted electricity each hour must not exceed transmission capacity
 

--- a/highres_data_input.gms
+++ b/highres_data_input.gms
@@ -55,6 +55,7 @@ parameter gen_mindown(non_vre);
 parameter gen_inertia(non_vre);
 
 parameter trans_links_cap(z,z_alias,trans);
+parameter trans_links_lim_cap(z,z_alias,trans);
 parameter trans_links_dist(z,z_alias,trans);
 parameter trans_loss(trans);
 parameter trans_varom(trans);

--- a/highres_results.gms
+++ b/highres_results.gms
@@ -46,6 +46,7 @@ parameter o_transVarC;
 o_transVarC=sum((trans_links(z,z_alias,trans),h),
     var_trans_flow.L(h,z,z_alias,trans)*trans_varom(trans))
 
+$ontext
 
 * Annualised fixed costs
 parameter o_capitalC;
@@ -69,6 +70,8 @@ o_transCapc=sum(trans_links(z,z_alias,trans),var_trans_pcap.l(z,z_alias,trans)
     *trans_links_dist(z,z_alias,trans)*trans_line_capex(trans))
     +sum(trans_links(z,z_alias,trans),var_trans_pcap.l(z,z_alias,trans)
     *trans_sub_capex(trans)*2)
+    
+
 
 * store costs
 
@@ -90,6 +93,8 @@ o_capitalC_tot=o_capitalstoreC+o_capitalC
 parameter o_variableC_tot;
 o_variableC_tot=o_variablestoreC+o_variableC
 
+$offtext
+
 
 ***************
 *Emissions
@@ -109,7 +114,8 @@ o_emissions_all=Sum((h,z,non_vre), o_emissions(h,z,non_vre));
 ***************
 
 parameter o_trans_cap_sum(trans);
-o_trans_cap_sum(trans)=sum((z,z_alias),var_trans_pcap.L(z,z_alias,trans))/2 ;
+o_trans_cap_sum(trans)=sum((z,z_alias),var_new_trans_pcap.L(z,z_alias,trans))/2
+                        +sum((z,z_alias),var_exist_trans_pcap.L(z,z_alias,trans))/2;
 
 *   -sum(h,var_trans_flow.l(h,z_alias,z,trans))
 *   +sum(h,var_trans_flow.l(h,z,z_alias,trans)*(1-


### PR DESCRIPTION
… Existing capacity is always set fixed based on TYNDP 2024 Ref grid for 2030. Add switch to move through three scenarios for new capacity: i) no new investment (OFF), ii) upper capacity limit constrained to TYNDP 2024 new line candidates (TYNDP), including Real and Concept lines, iii) investment up to user specified limit per line (USER).

Feature requires WF data2dd_funcs to be updated to provide TYNDP data (see WF commit 99850cb) and update to technoeconomic database.